### PR TITLE
Disable required toggle for title/section fields

### DIFF
--- a/Client/Components/FieldEditor.razor
+++ b/Client/Components/FieldEditor.razor
@@ -100,10 +100,13 @@
             </div>
         }
 
-        <div class="form-check mt-3">
-            <input class="form-check-input" type="checkbox" @bind="Field.IsRequired" />
-            <label class="form-check-label">Required</label>
-        </div>
+        @if (Field.FieldType != "title" && Field.FieldType != "section")
+        {
+            <div class="form-check mt-3">
+                <input class="form-check-input" type="checkbox" @bind="Field.IsRequired" />
+                <label class="form-check-label">Required</label>
+            </div>
+        }
     </div>
 </div>
 

--- a/Client/Components/LivePreview.razor
+++ b/Client/Components/LivePreview.razor
@@ -12,7 +12,10 @@
     @foreach (var field in row.Fields)
     {
         <div class="col-12 col-md-@(12 / (row.Fields.Count == 0 ? 1 : row.Fields.Count)) mb-3">
-            <label class="form-label">@field.Label</label>
+            @if (field.FieldType != "title" && field.FieldType != "section")
+            {
+                <label class="form-label">@field.Label</label>
+            }
 
         @switch (field.FieldType)
         {

--- a/Client/Pages/DynamicForms/FormDesigner.razor
+++ b/Client/Pages/DynamicForms/FormDesigner.razor
@@ -93,10 +93,13 @@
                 </div>
             </div>
 
-            <div class="form-check mt-2">
-                <input class="form-check-input" type="checkbox" @bind="field.IsRequired" />
-                <label class="form-check-label">Required</label>
-            </div>
+            @if (field.FieldType != "title" && field.FieldType != "section")
+            {
+                <div class="form-check mt-2">
+                    <input class="form-check-input" type="checkbox" @bind="field.IsRequired" />
+                    <label class="form-check-label">Required</label>
+                </div>
+            }
         </div>
     </div>
 }


### PR DESCRIPTION
## Summary
- hide the Required checkbox in FieldEditor when the field type is `title` or `section`
- apply same logic in the basic form designer page

## Testing
- `dotnet build DynamicFormsApp.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877a37fe95083298a1854856abb169d