### PR TITLE
Display submission message for anonymous users

### DIFF
--- a/Client/Pages/DynamicForms/FormRenderer.razor
+++ b/Client/Pages/DynamicForms/FormRenderer.razor
@@ -326,7 +326,16 @@ else
         }
 
         await Http.PostAsJsonAsync($"api/forms/{FormId}/responses", responseData);
-        Navigation.NavigateTo($"/forms/{FormId}/responses");
+
+        var user = await CookieHelper.LoginStatus();
+        if (string.IsNullOrEmpty(user))
+        {
+            Navigation.NavigateTo($"/forms/{FormId}/submitted", true);
+        }
+        else
+        {
+            Navigation.NavigateTo($"/forms/{FormId}/responses");
+        }
     }
 
     bool IsEmpty(object value)

--- a/Client/Pages/DynamicForms/FormSubmitted.razor
+++ b/Client/Pages/DynamicForms/FormSubmitted.razor
@@ -1,0 +1,35 @@
+@page "/forms/{FormId:int}/submitted"
+@using System.Net.Http.Json
+@inject HttpClient Http
+@inject NavigationManager Navigation
+
+<h3 class="mb-3">Response Submitted</h3>
+@if (form == null)
+{
+    <p>Loading form details...</p>
+}
+else
+{
+    <div class="alert alert-success">Your response has been submitted.</div>
+    <h4 class="mt-3">@form.Name</h4>
+    <p class="text-muted">@form.Description</p>
+}
+
+@code {
+    [Parameter] public int FormId { get; set; }
+
+    private Form? form;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            var response = await Http.GetAsync($"api/forms/{FormId}");
+            if (response.IsSuccessStatusCode)
+            {
+                form = await response.Content.ReadFromJsonAsync<Form>();
+            }
+            StateHasChanged();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- navigate anonymous users to a new confirmation page after form submission
- add `FormSubmitted` page showing form name and description

## Testing
- `dotnet build DynamicFormsApp.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_6877d07450f48329b446ece9ceccb333