### PR TITLE
Display submission message for anonymous users

### DIFF
--- a/Client/Components/FormUnavailableDisplay.razor
+++ b/Client/Components/FormUnavailableDisplay.razor
@@ -1,0 +1,26 @@
+@using DynamicFormsApp.Shared.Models
+@inherits LayoutComponentBase
+
+<div class="card border-warning mb-3">
+    <div class="card-header bg-warning text-dark">
+        @Info.Message
+    </div>
+    <div class="card-body">
+        <h5 class="card-title">@Info.FormName</h5>
+        @if (!string.IsNullOrWhiteSpace(Info.FormDescription))
+        {
+            <p class="card-text">@Info.FormDescription</p>
+        }
+        <p class="mb-0">Owner: @Info.Owner
+            @if (!string.IsNullOrEmpty(Info.Email))
+            {
+                <span>(@Info.Email)</span>
+            }
+        </p>
+    </div>
+</div>
+
+@code {
+    [Parameter]
+    public DeletedFormInfo Info { get; set; } = default!;
+}

--- a/Client/Layout/MainLayout.razor
+++ b/Client/Layout/MainLayout.razor
@@ -1,4 +1,5 @@
 ﻿@inherits LayoutComponentBase
+@using DynamicFormsApp.Shared.Models
 <RadzenComponents />
 
 <!-- Define the overall layout of the page using RadzenLayout -->
@@ -13,8 +14,13 @@
                 <RadzenSidebarToggle Click="@SidebarToggleClick" Icon="@sidebarToggleIcon"></RadzenSidebarToggle>
             </RadzenColumn>
 
+            <!-- Column for breadcrumb navigation -->
+            <RadzenColumn Size="6">
+                <BreadcrumbNav />
+            </RadzenColumn>
+
             <!-- Column for user-related actions -->
-            <RadzenColumn Size="10">
+            <RadzenColumn Size="4">
                 <RadzenStack AlignItems="AlignItems.Center" Orientation="Orientation.Horizontal" JustifyContent="JustifyContent.End">
                     @if (waitingforuserload)
                     {
@@ -38,11 +44,6 @@
                         <RadzenProgressBarCircular ProgressBarStyle="Radzen.ProgressBarStyle.Warning" Value="100" ShowValue="false" Mode="ProgressBarMode.Indeterminate" Size="Radzen.ProgressBarCircularSize.Small" />
                     }
                 </RadzenStack>
-            </RadzenColumn>
-        </RadzenRow>
-        <RadzenRow>
-            <RadzenColumn Size="12">
-                <BreadcrumbNav />
             </RadzenColumn>
         </RadzenRow>
     </RadzenHeader>
@@ -78,7 +79,7 @@
                 {
                     <RadzenButton Icon="bug_report" Click="@ReportBug" Text="Report Bug" ButtonStyle="ButtonStyle.Warning" Style="border-radius: 4px; margin: 10px;" class=@dynamicClass></RadzenButton>
                 }
-                <RadzenText Text="DynamicFormsApp v0.9.0" TextStyle="Radzen.Blazor.TextStyle.Caption" TagName="Radzen.Blazor.TagName.P" TextAlign="Radzen.TextAlign.Center" class=@dynamicClass />
+                <RadzenText Text="DynamicFormsApp v@AppInfo.Version" TextStyle="Radzen.Blazor.TextStyle.Caption" TagName="Radzen.Blazor.TagName.P" TextAlign="Radzen.TextAlign.Center" class=@dynamicClass />
             </RadzenStack>
         </div>
     </RadzenSidebar>

--- a/Client/Pages/DynamicForms/DeletedFormsAdmin.razor
+++ b/Client/Pages/DynamicForms/DeletedFormsAdmin.razor
@@ -79,7 +79,9 @@ else
                 return;
             }
 
-            forms = await Http.GetFromJsonAsync<List<Form>>("api/forms/deleted");
+            forms = (await Http.GetFromJsonAsync<List<Form>>("api/forms/deleted"))
+                ?.Where(f => !f.IsDraft)
+                .ToList();
             StateHasChanged();
         }
     }

--- a/Client/Pages/DynamicForms/EditFormPage.razor
+++ b/Client/Pages/DynamicForms/EditFormPage.razor
@@ -14,7 +14,11 @@
 @implements IDisposable
 
 <h2 class="mb-2">Form Builder</h2>
-@if (!string.IsNullOrEmpty(deletedMessage))
+@if (unavailableInfo != null)
+{
+    <FormUnavailableDisplay Info="@unavailableInfo" />
+}
+else if (!string.IsNullOrEmpty(deletedMessage))
 {
     <div class="alert alert-warning">@deletedMessage</div>
 }
@@ -135,6 +139,7 @@ else
     private UserModel? currentUser;
     private DotNetObjectReference<DynamicFormsApp.Client.Pages.DynamicForms.EditFormPage>? objRef;
     private string? deletedMessage;
+    private DeletedFormInfo? unavailableInfo;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -156,8 +161,7 @@ else
             {
                 if (resp.StatusCode == HttpStatusCode.Gone)
                 {
-                    var info = await resp.Content.ReadFromJsonAsync<DeletedFormInfo>();
-                    deletedMessage = $"{info?.Message} Contact {info?.Owner} ({info?.Email}).";
+                    unavailableInfo = await resp.Content.ReadFromJsonAsync<DeletedFormInfo>();
                 }
                 else
                 {

--- a/Client/Pages/DynamicForms/FormHistory.razor
+++ b/Client/Pages/DynamicForms/FormHistory.razor
@@ -7,7 +7,11 @@
 @inject CookieHelper CookieHelper
 
 <h3 class="mb-3">Form Versions</h3>
-@if (!string.IsNullOrEmpty(deletedMessage))
+@if (unavailableInfo != null)
+{
+    <FormUnavailableDisplay Info="@unavailableInfo" />
+}
+else if (!string.IsNullOrEmpty(deletedMessage))
 {
     <div class="alert alert-warning">@deletedMessage</div>
 }
@@ -36,6 +40,7 @@ else
     [Parameter] public int FormId { get; set; }
     private List<Form>? versions;
     private string? deletedMessage;
+    private DeletedFormInfo? unavailableInfo;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -54,8 +59,7 @@ else
             {
                 if (resp.StatusCode == HttpStatusCode.Gone)
                 {
-                    var info = await resp.Content.ReadFromJsonAsync<DeletedFormInfo>();
-                    deletedMessage = $"{info?.Message} Contact {info?.Owner} ({info?.Email}).";
+                    unavailableInfo = await resp.Content.ReadFromJsonAsync<DeletedFormInfo>();
                 }
                 else
                 {

--- a/Client/Pages/DynamicForms/FormRenderer.razor
+++ b/Client/Pages/DynamicForms/FormRenderer.razor
@@ -9,11 +9,15 @@
 @inject NavigationManager Navigation
 @inject CookieHelper CookieHelper
 
-<h3>@(!string.IsNullOrEmpty(statusMessage)
+<h3>@(!string.IsNullOrEmpty(statusMessage) || unavailableInfo != null
         ? "Form Not Available"
         : form?.Name ?? "Loading…")</h3>
 <p class="text-muted">@form?.Description</p>
-@if (!string.IsNullOrEmpty(statusMessage))
+@if (unavailableInfo != null)
+{
+    <FormUnavailableDisplay Info="@unavailableInfo" />
+}
+else if (!string.IsNullOrEmpty(statusMessage))
 {
     <div class="alert alert-warning">@statusMessage</div>
 }
@@ -176,6 +180,7 @@ else
     private Form form;
     private Dictionary<string, object> responseData = new();
     private string? statusMessage;
+    private DeletedFormInfo? unavailableInfo;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -186,8 +191,7 @@ else
             {
                 if (resp.StatusCode == HttpStatusCode.Gone)
                 {
-                    var info = await resp.Content.ReadFromJsonAsync<DeletedFormInfo>();
-                    statusMessage = $"{info?.Message} Contact {info?.Owner} ({info?.Email}).";
+                    unavailableInfo = await resp.Content.ReadFromJsonAsync<DeletedFormInfo>();
                 }
                 else
                 {

--- a/Client/Pages/DynamicForms/FormRenderer.razor
+++ b/Client/Pages/DynamicForms/FormRenderer.razor
@@ -85,8 +85,8 @@ else
 
                     case "dropdown":
                         var ddOptions = JsonSerializer.Deserialize<List<string>>(fld.OptionsJson ?? "[]");
-                        <select class="form-select"
-                                @onchange="e => OnTextChanged(fld.Key, e)">
+                        <select class="form-select" value="@GetString(fld.Key)" @onchange="e => OnTextChanged(fld.Key, e)">
+                            <option value="" disabled selected>Select...</option>
                             @foreach (var opt in ddOptions)
                             {
                                 <option value="@opt">@opt</option>

--- a/Client/Pages/DynamicForms/FormRenderer.razor
+++ b/Client/Pages/DynamicForms/FormRenderer.razor
@@ -326,7 +326,16 @@ else
         }
 
         await Http.PostAsJsonAsync($"api/forms/{FormId}/responses", responseData);
-        Navigation.NavigateTo($"/forms/{FormId}/responses");
+
+        var user = await CookieHelper.LoginStatus();
+        if (string.IsNullOrEmpty(user))
+        {
+            Navigation.NavigateTo($"/forms/{FormId}/submitted", true);
+        }
+        else
+        {
+            Navigation.NavigateTo($"/forms/{FormId}/responses");
+        }
     }
 
     bool IsEmpty(object value)

--- a/Client/Pages/DynamicForms/FormResponses.razor
+++ b/Client/Pages/DynamicForms/FormResponses.razor
@@ -12,7 +12,11 @@
 <div class="container mt-4">
     <h2 class="mb-4">📄 Responses: <span class="text-primary">@form?.Name</span></h2>
     <p class="text-muted">@form?.Description</p>
-    @if (!string.IsNullOrEmpty(deletedMessage))
+    @if (unavailableInfo != null)
+    {
+        <FormUnavailableDisplay Info="@unavailableInfo" />
+    }
+    else if (!string.IsNullOrEmpty(deletedMessage))
     {
         <div class="alert alert-warning">@deletedMessage</div>
     }
@@ -97,6 +101,7 @@
     private string[] columns = Array.Empty<string>();
     private IJSObjectReference? exportModule;
     private string? deletedMessage;
+    private DeletedFormInfo? unavailableInfo;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -116,8 +121,7 @@
             {
                 if (respForm.StatusCode == HttpStatusCode.Gone)
                 {
-                    var info = await respForm.Content.ReadFromJsonAsync<DeletedFormInfo>();
-                    deletedMessage = $"{info?.Message} Contact {info?.Owner} ({info?.Email}).";
+                    unavailableInfo = await respForm.Content.ReadFromJsonAsync<DeletedFormInfo>();
                 }
                 else
                 {

--- a/Client/Pages/DynamicForms/FormSubmitted.razor
+++ b/Client/Pages/DynamicForms/FormSubmitted.razor
@@ -1,0 +1,35 @@
+@page "/forms/{FormId:int}/submitted"
+@using System.Net.Http.Json
+@inject HttpClient Http
+@inject NavigationManager Navigation
+
+<h3 class="mb-3">Response Submitted</h3>
+@if (form == null)
+{
+    <p>Loading form details...</p>
+}
+else
+{
+    <div class="alert alert-success">Your response has been submitted.</div>
+    <h4 class="mt-3">@form.Name</h4>
+    <p class="text-muted">@form.Description</p>
+}
+
+@code {
+    [Parameter] public int FormId { get; set; }
+
+    private Form? form;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            var response = await Http.GetAsync($"api/forms/{FormId}");
+            if (response.IsSuccessStatusCode)
+            {
+                form = await response.Content.ReadFromJsonAsync<Form>();
+            }
+            StateHasChanged();
+        }
+    }
+}

--- a/Client/Pages/DynamicForms/FormSummary.razor
+++ b/Client/Pages/DynamicForms/FormSummary.razor
@@ -9,7 +9,11 @@
 
 <h3>Summary for @form?.Name</h3>
 <p class="text-muted">@form?.Description</p>
-@if (!string.IsNullOrEmpty(deletedMessage))
+@if (unavailableInfo != null)
+{
+    <FormUnavailableDisplay Info="@unavailableInfo" />
+}
+else if (!string.IsNullOrEmpty(deletedMessage))
 {
     <div class="alert alert-warning">@deletedMessage</div>
 }
@@ -76,6 +80,7 @@ else
     private Form form;
     private List<Dictionary<string, object>> responses;
     private string? deletedMessage;
+    private DeletedFormInfo? unavailableInfo;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -94,8 +99,7 @@ else
             {
                 if (respForm.StatusCode == HttpStatusCode.Gone)
                 {
-                    var info = await respForm.Content.ReadFromJsonAsync<DeletedFormInfo>();
-                    deletedMessage = $"{info?.Message} Contact {info?.Owner} ({info?.Email}).";
+                    unavailableInfo = await respForm.Content.ReadFromJsonAsync<DeletedFormInfo>();
                 }
                 else
                 {

--- a/Client/Pages/DynamicForms/MyForms.razor
+++ b/Client/Pages/DynamicForms/MyForms.razor
@@ -45,12 +45,17 @@ else
                             <a class="btn btn-sm btn-secondary me-2" href="@($"/forms/{f.Id}/edit")">Edit</a>
                             <a class="btn btn-sm btn-secondary me-2" href="@($"/forms/{f.Id}/responses")">Responses</a>
                             <a class="btn btn-sm btn-info me-2" href="@($"/forms/{f.Id}/summary")">Summary</a>
-                            <button class="btn btn-sm btn-outline-secondary me-2" @onclick="() => ShareForm(f.Id)">Share</button>
+                            <button class="btn btn-sm btn-outline-secondary me-2" @onclick="() => ShareForm(f.Id)">
+                                <span class="material-icons">share</span>
+                                <span class="badge bg-secondary ms-1">@GetShareCount(f.Id)</span>
+                            </button>
                             @if (f.PreviousVersionId != null)
                             {
                                 <a class="btn btn-sm btn-outline-secondary me-2" href="@($"/forms/{f.Id}/history")">History</a>
                             }
-                            <button class="btn btn-sm btn-danger" @onclick="() => DeleteForm(f.Id)">Delete</button>
+                            <button class="btn btn-sm btn-danger" title="Delete" @onclick="() => DeleteForm(f.Id)">
+                                <span class="material-icons">delete</span>
+                            </button>
                         </td>
                     </tr>
                 }
@@ -61,6 +66,7 @@ else
 
 @code {
     private List<Form>? forms;
+    private Dictionary<int, int> shareCounts = new();
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -75,6 +81,7 @@ else
             }
 
             forms = await Http.GetFromJsonAsync<List<Form>>("api/forms/mine");
+            await LoadShareCounts();
             StateHasChanged();
         }
     }
@@ -136,7 +143,28 @@ else
             ["FormId"] = id
         };
 
-        await DialogService.OpenAsync<ShareFormDialog>("Share Form", parameters,
+        var result = await DialogService.OpenAsync<ShareFormDialog>("Share Form", parameters,
             new DialogOptions { Width = "500px" });
+        if (result is bool b && b)
+        {
+            await LoadShareCount(id);
+            StateHasChanged();
+        }
+    }
+
+    private int GetShareCount(int id) => shareCounts.TryGetValue(id, out var c) ? c : 0;
+
+    private async Task LoadShareCounts()
+    {
+        foreach (var f in forms ?? Enumerable.Empty<Form>())
+        {
+            await LoadShareCount(f.Id);
+        }
+    }
+
+    private async Task LoadShareCount(int id)
+    {
+        var shares = await Http.GetFromJsonAsync<List<FormShare>>($"api/forms/{id}/shares");
+        shareCounts[id] = shares?.Count ?? 0;
     }
 }

--- a/Client/Pages/DynamicForms/ViewResponse.razor
+++ b/Client/Pages/DynamicForms/ViewResponse.razor
@@ -20,7 +20,11 @@
     </div>
 
 </div>
-@if (!string.IsNullOrEmpty(deletedMessage))
+@if (unavailableInfo != null)
+{
+    <FormUnavailableDisplay Info="@unavailableInfo" />
+}
+else if (!string.IsNullOrEmpty(deletedMessage))
 {
     <div class="alert alert-warning">@deletedMessage</div>
 }
@@ -106,6 +110,7 @@ else
     private string? responderName;
     private IJSObjectReference? exportModule;
     private string? deletedMessage;
+    private DeletedFormInfo? unavailableInfo;
 
     int? PrevId =>
         responseIds != null && responseIds.IndexOf(ResponseId) > 0
@@ -147,8 +152,7 @@ else
         {
             if (respForm.StatusCode == HttpStatusCode.Gone)
             {
-                var info = await respForm.Content.ReadFromJsonAsync<DeletedFormInfo>();
-                deletedMessage = $"{info?.Message} Contact {info?.Owner} ({info?.Email}).";
+                unavailableInfo = await respForm.Content.ReadFromJsonAsync<DeletedFormInfo>();
             }
             else
             {

--- a/Client/Pages/Index.razor
+++ b/Client/Pages/Index.razor
@@ -11,47 +11,49 @@
 
 <div class="row row-cols-1 row-cols-md-4 g-3 mb-5 justify-content-center">
     <div class="col" style="max-width:200px;">
-        <div class="card text-center h-100">
-            <div class="card-body">
-                <h3>@totalForms</h3>
-                <p class="text-muted mb-0">Total Forms</p>
+        <a href="/forms/new" class="text-decoration-none">
+            <div class="card text-center h-100">
+                <div class="card-body">
+                    <span class="material-icons" style="font-size:3rem;">add_circle</span>
+                    <p class="text-muted mb-0">Create Form</p>
+                </div>
             </div>
-        </div>
+        </a>
     </div>
     <div class="col" style="max-width:200px;">
-        <div class="card text-center h-100">
-            <div class="card-body">
-                <h3>@myForms</h3>
-                <p class="text-muted mb-0">My Forms</p>
+        <a href="/myforms" class="text-decoration-none">
+            <div class="card text-center h-100">
+                <div class="card-body">
+                    <h3>@myForms</h3>
+                    <p class="text-muted mb-0">My Forms</p>
+                </div>
             </div>
-        </div>
+        </a>
     </div>
     <div class="col" style="max-width:200px;">
-        <div class="card text-center h-100">
-            <div class="card-body">
-                <h3>@drafts</h3>
-                <p class="text-muted mb-0">Drafts</p>
+        <a href="/draftforms" class="text-decoration-none">
+            <div class="card text-center h-100">
+                <div class="card-body">
+                    <h3>@drafts</h3>
+                    <p class="text-muted mb-0">Drafts</p>
+                </div>
             </div>
-        </div>
+        </a>
     </div>
     <div class="col" style="max-width:200px;">
-        <div class="card text-center h-100">
-            <div class="card-body">
-                <h3>@shared</h3>
-                <p class="text-muted mb-0">Shared With Me</p>
+        <a href="/sharedforms" class="text-decoration-none">
+            <div class="card text-center h-100">
+                <div class="card-body">
+                    <h3>@shared</h3>
+                    <p class="text-muted mb-0">Shared With Me</p>
+                </div>
             </div>
-        </div>
+        </a>
     </div>
 </div>
 
-<div class="d-flex justify-content-center gap-3 mb-4">
-    <a href="/forms/new" class="btn btn-primary">Create Form</a>
-    <a href="/myforms" class="btn btn-secondary">My Forms</a>
-    <a href="/sharedforms" class="btn btn-secondary">Shared With Me</a>
-</div>
 
 @code {
-    private int totalForms;
     private int myForms;
     private int drafts;
     private int shared;
@@ -67,7 +69,6 @@
             }
             else
             {
-                totalForms = await Http.GetFromJsonAsync<int>("api/forms/count");
                 var mine = await Http.GetFromJsonAsync<List<Form>>("api/forms/mine");
                 myForms = mine?.Count(f => f.IsActive) ?? 0;
                 var draftsList = await Http.GetFromJsonAsync<List<Form>>("api/forms/drafts");

--- a/NdaProcesses.Shared/Models/AppInfo.cs
+++ b/NdaProcesses.Shared/Models/AppInfo.cs
@@ -1,0 +1,6 @@
+namespace DynamicFormsApp.Shared.Models;
+
+public static class AppInfo
+{
+    public const string Version = "0.9.1";
+}

--- a/NdaProcesses.Shared/Models/DeletedFormInfo.cs
+++ b/NdaProcesses.Shared/Models/DeletedFormInfo.cs
@@ -5,5 +5,7 @@ namespace DynamicFormsApp.Shared.Models
         public string Message { get; set; } = string.Empty;
         public string Owner { get; set; } = string.Empty;
         public string? Email { get; set; }
+        public string FormName { get; set; } = string.Empty;
+        public string? FormDescription { get; set; }
     }
 }

--- a/Server/Components/App.razor
+++ b/Server/Components/App.razor
@@ -1,4 +1,5 @@
 @inject NavigationManager NavigationManager
+@using DynamicFormsApp.Shared.Models
 <!DOCTYPE html>
 <html lang="en">
 
@@ -9,9 +10,9 @@
     <RadzenTheme @rendermode="@InteractiveWebAssembly" Theme="dark" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" />
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
-    <link rel="stylesheet" href="css/site.css" />
-    <link href="css/app.css" rel="stylesheet" />
-    <link href="css/form-builder.css" rel="stylesheet" />
+    <link rel="stylesheet" href="css/site.css?v=@AppInfo.Version" />
+    <link href="css/app.css?v=@AppInfo.Version" rel="stylesheet" />
+    <link href="css/form-builder.css?v=@AppInfo.Version" rel="stylesheet" />
     <link rel="icon" href="favicon.ico" />
     <link href="manifest.json" rel="manifest" />
     <link rel="apple-touch-icon" sizes="512x512" href="icon-512.png" />
@@ -20,9 +21,9 @@
 
 <body data-bs-theme="dark">
     <Routes @rendermode="@InteractiveWebAssembly" />
-    <script src="_framework/blazor.web.js"></script>
-    <script src="_content/Radzen.Blazor/Radzen.Blazor.js?v=@(typeof(Radzen.Colors).Assembly.GetName().Version)"></script>
-    <script>navigator.serviceWorker.register('service-worker.js');</script>
+    <script src="_framework/blazor.web.js?v=@AppInfo.Version"></script>
+    <script src="_content/Radzen.Blazor/Radzen.Blazor.js?v=@(typeof(Radzen.Colors).Assembly.GetName().Version)&app=@AppInfo.Version"></script>
+    <script>navigator.serviceWorker.register('service-worker.js?v=@AppInfo.Version');</script>
     <script src="js/cookieHelper.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
     <script src="js/sortable-wrapper.js"></script>

--- a/Server/Controllers/FormsController.cs
+++ b/Server/Controllers/FormsController.cs
@@ -367,7 +367,9 @@ namespace DynamicFormsApp.Server.Controllers
             {
                 Message = message,
                 Owner = owner?.DisplayName ?? form.CreatedBy,
-                Email = owner?.Email
+                Email = owner?.Email,
+                FormName = form.Name,
+                FormDescription = form.Description
             });
         }
     }

--- a/Server/Services/DynamicFormService.cs
+++ b/Server/Services/DynamicFormService.cs
@@ -325,7 +325,7 @@ namespace DynamicFormsApp.Server.Services
         {
             return await _db.Forms
                 .Include(f => f.Fields)
-                .Where(f => f.IsDeleted)
+                .Where(f => f.IsDeleted && !f.IsDraft)
                 .ToListAsync();
         }
 


### PR DESCRIPTION
## Summary
- navigate anonymous users to a new confirmation page after form submission
- add `FormSubmitted` page showing form name and description

## Testing
- `dotnet build DynamicFormsApp.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_6877d07450f48329b446ece9ceccb333