### PR TITLE
Add Windows Authentication

### DIFF
--- a/.vs/DynamicFormsApp/config/applicationhost.config
+++ b/.vs/DynamicFormsApp/config/applicationhost.config
@@ -318,7 +318,7 @@
 
             <authentication>
 
-                <anonymousAuthentication enabled="true" userName="" />
+                <anonymousAuthentication enabled="false" userName="" />
 
                 <basicAuthentication enabled="false" />
 
@@ -329,7 +329,7 @@
                 <iisClientCertificateMappingAuthentication enabled="false">
                 </iisClientCertificateMappingAuthentication>
 
-                <windowsAuthentication enabled="false">
+                <windowsAuthentication enabled="true">
                     <providers>
                         <add value="Negotiate" />
                         <add value="NTLM" />

--- a/Client/DynamicFormsApp.Client.csproj
+++ b/Client/DynamicFormsApp.Client.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="System.Linq.Dynamic.Core" Version="1.4.9" />
     <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
     <PackageReference Include="Radzen.Blazor" Version="*" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <Compile Include="../Server/Models/**/*.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Client/Pages/Users/Login.razor
+++ b/Client/Pages/Users/Login.razor
@@ -1,109 +1,35 @@
 @page "/login"
 @using Radzen
 @using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Http
+@inject IHttpContextAccessor HttpContextAccessor
 
 <PageTitle>Login</PageTitle>
 
-@if (isLoading)
+@if (!isAuthenticated)
 {
     <RadzenRow>
-        <RadzenText Text="Loading" TextStyle="Radzen.Blazor.TextStyle.H5" />
-        <RadzenProgressBarCircular ProgressBarStyle="Radzen.ProgressBarStyle.Warning" Value="100" ShowValue="false" Mode="ProgressBarMode.Indeterminate" Size="Radzen.ProgressBarCircularSize.Small" />
+        <RadzenText Text="Windows authentication required." TextStyle="Radzen.Blazor.TextStyle.H5" />
     </RadzenRow>
-}
-else
-{
-    <RadzenTemplateForm Data="@user" TItem="UserModel" Submit="@OnSubmit">
-        <RadzenCard Style="width:400px;margin:auto;margin-top:100px;">
-            <RadzenText Text="Login" TextStyle="Radzen.Blazor.TextStyle.DisplayH3" Style="text-align: center" />
-            <RadzenFieldset Legend="Login Information" Style="border: 1px none #45565e">
-                <RadzenLabel Text="Username" Component="RadzenTextBox1" />
-                <RadzenTextBox @bind-Value="user.UserName" Style="width:100%;" Name="Username" />
-                <RadzenLabel Text="Password" Component="RadzenPassword1" />
-                <RadzenFormField Style="width:100%; margin-top:-8px;">
-                    <ChildContent>
-                        <RadzenPassword @bind-Value="user.Password" Style="width:100%;" Name="Password" Visible="@passwordVisible" />
-                        <RadzenTextBox @bind-Value="user.Password" Name="Password" Visible="@(!passwordVisible)" />
-                    </ChildContent>
-                    <End>
-                        <RadzenButton Icon="@(passwordVisible ? "visibility" : "visibility_off")"
-                                      @onmousedown="ShowPassword"
-                                      @onmouseup="HidePassword"
-                                      @onmouseleave="HidePassword"
-                                      Variant="Variant.Text"
-                                      Size="ButtonSize.Small"
-                                      IconColor="@Colors.Warning" />
-                    </End>
-                </RadzenFormField>
-            </RadzenFieldset>
-            <RadzenAlert AlertStyle="AlertStyle.Danger" Variant="Variant.Flat" @bind-Visible=errorMessage Shade="Shade.Lighter">
-                Invalid Username or Password.
-            </RadzenAlert>
-            <RadzenButton ButtonType="ButtonType.Submit" IsBusy="@busy" ButtonStyle="ButtonStyle.Success" Text="Login" Style="width: 70%; margin-left: 15%; margin-right: 15%" />
-        </RadzenCard>
-    </RadzenTemplateForm>
 }
 
 @code {
-    private UserModel user = new UserModel();
-    private bool errorMessage = false;
-    private bool busy;
-    private bool isLoading = true;
-    bool passwordVisible = true;
+    private bool isAuthenticated;
+    private string? userName;
 
-    protected override async Task OnAfterRenderAsync(bool firstRender)
+    protected override void OnInitialized()
     {
-        if (firstRender)
+        var context = HttpContextAccessor.HttpContext;
+        isAuthenticated = context?.User?.Identity?.IsAuthenticated ?? false;
+        if (isAuthenticated)
         {
-            // Hide loading spinner after the initial render
-            isLoading = false;
-            StateHasChanged();
-        }
-    }
-
-    private async Task OnSubmit()
-    {
-        if (string.IsNullOrEmpty(user.UserName) || string.IsNullOrEmpty(user.Password))
-        {
-            errorMessage = true;
-            return;
-        }
-        user.UserName = user.UserName?.Trim();
-
-        user.Password = user.Password?.Trim();
-
-        busy = true;
-        StateHasChanged();
-
-        // Authenticate user
-
-        if (await UserService.ValidateUser(user))
-        {
-            // Set cookie for user identification
-            await CookieHelper.LoginUser(user.UserName);
-
-            // Get the returnUrl query parameter
+            userName = context?.User?.Identity?.Name;
             var uri = new Uri(NavigationManager.Uri);
-            var returnUrl = uri.Query.Contains("returnUrl") ? uri.Query.Substring(uri.Query.IndexOf("returnUrl") + 10) : "/";
+            var returnUrl = uri.Query.Contains("returnUrl")
+                ? uri.Query.Substring(uri.Query.IndexOf("returnUrl") + 10)
+                : "/";
             returnUrl = Uri.UnescapeDataString(returnUrl);
-
-            // Navigate to the returnUrl or home page
             NavigationManager.NavigateTo(returnUrl, true);
         }
-        else
-        {
-            errorMessage = true;
-        }
-
-        busy = false;
-    }
-    private void ShowPassword()
-    {
-        passwordVisible = false; // Reveal password
-    }
-
-    private void HidePassword()
-    {
-        passwordVisible = true; // Hide password
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# DynamicFormsApp
+
+This application requires Windows Authentication to be enabled in IIS with anonymous authentication disabled. Browser clients must negotiate credentials automatically.

--- a/Server/DynamicFormsApp.Server.csproj
+++ b/Server/DynamicFormsApp.Server.csproj
@@ -18,6 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="8.0.0" />
     <PackageReference Include="Radzen.Blazor" Version="*" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.0" />
     <PackageReference Include="System.DirectoryServices" Version="8.0.0" />

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -6,6 +6,7 @@ using DynamicFormsApp.Server.Services;
 using DynamicFormsApp.Server.Data;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Authentication.Negotiate;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -47,6 +48,9 @@ builder.Services.AddControllers();
 builder.Services.AddRadzenComponents();
 builder.Services.AddHttpClient();
 builder.Services.AddHttpContextAccessor();
+builder.Services.AddAuthentication(NegotiateDefaults.AuthenticationScheme)
+                .AddNegotiate();
+builder.Services.AddAuthorization();
 builder.Services.AddControllersWithViews();
 builder.Services.AddRazorPages();
 var app = builder.Build();
@@ -65,6 +69,8 @@ else
 
 app.UseHttpsRedirection();
 app.UseResponseCompression();
+app.UseAuthentication();
+app.UseAuthorization();
 app.MapControllers();
 app.UseStaticFiles();
 app.UseAntiforgery();

--- a/Server/Properties/launchSettings.json
+++ b/Server/Properties/launchSettings.json
@@ -1,7 +1,7 @@
 {
   "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
+    "windowsAuthentication": true,
+    "anonymousAuthentication": false,
     "iisExpress": {
       "applicationUrl": "http://localhost:19712",
       "sslPort": 44395


### PR DESCRIPTION
## Summary
- enable Negotiate authentication in server
- add auth middleware pipeline
- switch login page to use Windows Authentication context
- configure windows auth in launch settings and IIS
- document Windows Authentication requirements

## Testing
- `dotnet build DynamicFormsApp.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_687a3bd02ee08329a650e1ec99de1c11